### PR TITLE
	modified:   katana-nbi/requirements.txt

### DIFF
--- a/katana-nbi/requirements.txt
+++ b/katana-nbi/requirements.txt
@@ -24,3 +24,6 @@ flask-cors
 
 # Kafka
 kafka-python==1.4.7
+
+# WSGI web application library
+werkzeug==2.1.2


### PR DESCRIPTION
  fix ImportError: cannot import name 'parse_rule' from
  'werkzeug.routing'
  (/usr/local/lib/python3.7/site-packages/werkzeug/routing/__init__.py)
  on building